### PR TITLE
Fix README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Fast implementation of QOI format.
 Reference implementation is here 'https://github.com/phoboslab/qoi'
 
 `rapid-qoi` is
-* no deps
 * no std
 * no unsafe
 * tiny


### PR DESCRIPTION
from v0.6.0, rapid-qoi depends on bytemuck. `no deps` is outdated information