### PR TITLE
Fix definition of unlikely

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,7 +582,7 @@ const fn likely(b: bool) -> bool {
 
 #[inline]
 const fn unlikely(b: bool) -> bool {
-    if !b {
+    if b {
         cold();
     }
     b


### PR DESCRIPTION
Previously, `unlikely` was defined the same as `likely`, and therefore suggesting to the optimiser the opposite of what it was supposed to; removing the `!` inverts the condition and makes `unlikely` have its intended behaviour.